### PR TITLE
Switch to git ls-remote for fetching tg remote versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,9 @@ name = "cc"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfb-mode"
@@ -585,6 +588,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.13.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "jobserver"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,10 +794,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.21+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -959,6 +1011,25 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+dependencies = [
+ "autocfg 1.0.1",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "pem"
@@ -1391,29 +1462,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b5842e81eb9bbea19276a9dbbda22ac042532f390a67ab08b895617978abf3"
+checksum = "d023dabf011d5dcb5ac64e3685d97d3b0ef412911077a2851455c6098524a723"
 
 [[package]]
 name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "serde_json"
@@ -1582,11 +1639,12 @@ dependencies = [
 
 [[package]]
 name = "terve"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "bytes",
  "dirs",
+ "git2",
  "hex",
  "pgp",
  "pico-args",
@@ -1594,7 +1652,6 @@ dependencies = [
  "regex",
  "reqwest",
  "semver",
- "serde",
  "sha2",
  "tempfile",
  "zip",
@@ -1790,6 +1847,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "terve"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jukka Palomäki <jukka@jpalomaki.fi>"]
 edition = "2018"
 
@@ -11,12 +11,12 @@ reqwest     = { version = "~0.11", default-features = false, features = ["rustls
 zip         = "~0.5"
 tempfile    = "~3.2"
 dirs        = "~3.0"
-serde       = { version = "~1.0", features = ["derive"] }
 semver      = "~1.0"
 sha2        = "~0.9"
 hex         = "~0.4"
 pgp         = "~0.7"
 bytes       = "~1.0"
+git2        = { version = "~0.13", default-features = false, features = ["https"] }
 
 [dev-dependencies]
 assert_cmd  = "~1.0"

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ Syntax: `terve l[ist] <binary> [spec]` where `spec` is `r[emote]`
 - `terve l tf r` lists available (remote) terraform versions
 - `terve l tg r | grep 0.29.` lists available terragrunt 0.29.x versions
 
-WARNING: list remote for terragrunt uses GitHub API which is rate-limited (GitHub API throws 403 Forbidden if rate-limit quota is depleted)!
-
 ### Install
 
 Installs a specific version.
@@ -91,13 +89,15 @@ Syntax: `terve r[emove] <binary> <semver>`
 
 ## Development
 
-You need rustup and cargo. See <https://rustup.rs/>. To run all tests, run `cargo test`.
+You need [cargo](https://rustup.rs/) and [OpenSSL pre-requisites](https://docs.rs/openssl#automatic). To run all tests, run `cargo test`.
 
 To build the binary, run `cargo build --release`. Binary is then found in `target/release/terve`.
+
+Visual Studio Code with [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer) provides a good IDE experience.
 
 ## TODOs
 
 - QA: Improve test coverage
 - CI: Release workflow (matrix: linux + darwin)
 - Err: more contextual error messages (anyhow?)
-- OS: Windows support (.exe symlink 🤔)
+- OS: Windows support (.exe symlink 🤔)?

--- a/src/http.rs
+++ b/src/http.rs
@@ -49,10 +49,6 @@ impl HttpClient {
             .text()?;
         Ok(text)
     }
-
-    pub fn custom(&self) -> &Client {
-        &self.client
-    }
 }
 
 const HTTP_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);


### PR DESCRIPTION
Better performance and less likely to hit GitHub rate limits