### PR TITLE
Use hard links instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f57fec1ac7e4de72dcc69811795f1a7172ed06012f80a5d1ee651b62484f588"
+checksum = "a88b6bd5df287567ffdf4ddf4d33060048e1068308e5f62d81c6f9824a045a48"
 dependencies = [
  "bstr",
  "doc-comment",
@@ -184,9 +184,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "bzip2"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
+checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.10+1.0.8"
+version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fa3d1ac1ca21c5c4e36a97f3c3eb25084576f6fc47bf0139c1123434216c6c"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
 dependencies = [
  "cc",
  "libc",
@@ -678,9 +678,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -692,7 +692,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
 
 [[package]]
 name = "libgit2-sys"
@@ -1002,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1099,29 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "pico-args"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7afeb98c5a10e0bffcc7fc16e105b04d06729fac5fd6384aebf7ff5cb5a67d"
-
-[[package]]
-name = "pin-project"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project-lite"
@@ -1226,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
@@ -1243,9 +1223,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.2",
@@ -1319,12 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
-dependencies = [
- "byteorder",
-]
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -1462,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023dabf011d5dcb5ac64e3685d97d3b0ef412911077a2851455c6098524a723"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "serde"
@@ -1602,9 +1579,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1817,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33717dca7ac877f497014e10d73f3acf948c342bee31b5ca7892faf94ccc6b49"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -2059,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c83dc9b784d252127720168abd71ea82bf8c3d96b17dc565b5e2a02854f2b27"
+checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
 dependencies = [
  "byteorder",
  "bzip2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -1428,6 +1428,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1637,7 @@ dependencies = [
  "predicates",
  "regex",
  "reqwest",
+ "same-file",
  "semver",
  "sha2",
  "tempfile",
@@ -1986,6 +1996,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ git2        = { version = "~0.13", default-features = false, features = ["https"
 [dev-dependencies]
 assert_cmd  = "~1.0"
 predicates  = "~1.0"
+same-file   = "~1.0"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ WARNING: this is a new project, and is very subject to change
 
 ## How it works
 
-Terve uses plain old symlinks to point to selected tool versions.
+Terve uses plain old symlinks to point to selected binary versions.
 
-NOTE: on Windows 10, symlink creation requires developer mode or admin permissions. If symlink support is unavailable, terve falls back to copying versioned binaries into `.terve/bin/` and logs a warning.
+NOTE: on Windows 10, symlink creation requires developer mode or admin permissions. If symlink support is unavailable, terve falls back to copying the binary into `$HOME/.terve/bin/` and logs a warning.
 
 All files are kept in directory `$HOME/.terve` like so (example for Linux):
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ WARNING: this is a new project, and is very subject to change
 
 ## How it works
 
-Terve uses hard links to point to selected terraform/terragrunt binary versions.
+Terve uses hard links to configure selected terraform/terragrunt binary versions.
 
 All files are kept in directory `~/.terve` like so (example directory tree for Linux):
 
@@ -92,7 +92,7 @@ Syntax: `terve r[emove] <binary> <semver>`
 - `terve r tf 0.12.31` removes terraform version 0.12.31
 - `terve l tf | grep 0.11. | xargs -n1 terve r tf` removes all installed terraform 0.11.x versions
 
-## Shell recipes
+## Shell extensions
 
 ### terve-use
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ WARNING: this is a new project, and is very subject to change
 
 ## How it works
 
-Terve uses simple symlinks to point to selected versions.
+Terve uses plain old symlinks to point to selected tool versions.
+
+NOTE: on Windows 10, symlink creation requires developer mode or admin permissions. If symlink support is unavailable, terve falls back to copying versioned binaries into `.terve/bin/` and logs a warning.
 
 All files are kept in directory `$HOME/.terve` like so (example for Linux):
 
@@ -92,6 +94,43 @@ Syntax: `terve r[emove] <binary> <semver>`
 - `terve r tf 0.12.31` removes terraform version 0.12.31
 - `terve l tf | grep 0.11. | xargs -n1 terve r tf` removes all installed terraform 0.11.x versions
 
+## Shell recipes
+
+### terve-use
+
+Use tool versions defined in `.terraform-version` and `.terragrunt-version` (in current working directory or any parent directory)
+
+```sh
+#!/bin/sh
+
+upcat() {
+    file="$1"
+    while [ "$PWD" != "/" ]; do
+        if [ -r "$file" ]; then
+            cat "$file"
+            break
+        fi
+        cd ..
+    done
+}
+
+tf_version="$(upcat .terraform-version)"
+tg_version="$(upcat .terragrunt-version)"
+
+if [ -z "$tf_version" ]; then
+    echo "ERROR: No .terraform-version found"
+    exit 1
+fi
+
+if [ -z "$tg_version" ]; then
+    echo "ERROR: No .terragrunt-version found"
+    exit 2
+fi
+
+terve i tf "$tf_version" && terve s tf "$tf_version"
+terve i tg "$tg_version" && terve s tg "$tg_version"
+```
+
 ## Development
 
 You need [cargo](https://rustup.rs/) and [OpenSSL pre-requisites](https://docs.rs/openssl#automatic). To run all tests, run `cargo test`.
@@ -102,6 +141,5 @@ Visual Studio Code with [rust-analyzer](https://marketplace.visualstudio.com/ite
 
 ## TODOs
 
-- Win 10: copy to bin if symlink support unavailable?
 - QA: Improve test coverage
 - CI: Release workflow (matrix: linux + darwin)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ WARNING: this is a new project, and is very subject to change
 
 Terve uses plain old symlinks to point to selected binary versions.
 
-NOTE: on Windows 10, symlink creation requires developer mode or admin permissions. If symlink support is unavailable, terve falls back to copying the binary into `$HOME/.terve/bin/` and logs a warning.
+NOTE: on Windows 10, symlink creation requires developer mode or admin permissions. If symlink support is unavailable, terve falls back to copying the binary into `~/.terve/bin/` and logs a warning.
 
-All files are kept in directory `$HOME/.terve` like so (example for Linux):
+All files are kept in directory `~/.terve` like so (example tree is for Linux):
 
 ```txt
 /home/whoami/.terve

--- a/README.md
+++ b/README.md
@@ -21,17 +21,15 @@ WARNING: this is a new project, and is very subject to change
 
 ## How it works
 
-Terve uses plain old symlinks to point to selected binary versions.
+Terve uses hard links to point to selected terraform/terragrunt binary versions.
 
-NOTE: on Windows 10, symlink creation requires developer mode or admin permissions. If symlink support is unavailable, terve falls back to copying the binary into `~/.terve/bin/` and logs a warning.
-
-All files are kept in directory `~/.terve` like so (example tree is for Linux):
+All files are kept in directory `~/.terve` like so (example directory tree for Linux):
 
 ```txt
 /home/whoami/.terve
 ├── bin
-│   ├── terraform -> /home/whoami/.terve/opt/terraform/0.15.4
-│   └── terragrunt -> /home/whoami/.terve/opt/terragrunt/0.28.10
+│   ├── terraform
+│   └── terragrunt
 ├── etc
 │   └── terraform.asc
 └── opt

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -142,7 +142,7 @@ pub fn select_binary_version(
     {
         use std::fs::copy;
         use std::os::windows::fs::symlink_file;
-        let copy_binary = || {
+        let copy_binary = |_| {
             eprint!("WARNING: Unable to create symlink, copying binary instead. See https://github.com/superblk/terve#how-it-works{}", utils::NEWLINE);
             copy(&opt_file_path, &symlink_path)
         };

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -140,8 +140,13 @@ pub fn select_binary_version(
     }
     #[cfg(windows)]
     {
+        use std::fs::copy;
         use std::os::windows::fs::symlink_file;
-        symlink_file(&opt_file_path, &symlink_path)?;
+        let copy_binary = || {
+            eprint!("WARNING: Unable to create symlink, copying binary instead. See https://github.com/superblk/terve#how-it-works{}", utils::NEWLINE);
+            copy(&opt_file_path, &symlink_path)
+        };
+        symlink_file(&opt_file_path, &symlink_path).or_else(copy_binary)?;
     }
     Ok(format!("Selected {} {}", binary, version))
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -141,8 +141,9 @@ pub fn select_binary_version(
     #[cfg(windows)]
     {
         use std::fs::copy;
+        use std::io;
         use std::os::windows::fs::symlink_file;
-        let copy_binary = |_| {
+        let copy_binary = |_| -> io::Result<()> {
             eprint!("WARNING: Unable to create symlink, copying binary instead. See https://github.com/superblk/terve#how-it-works{}", utils::NEWLINE);
             copy(&opt_file_path, &symlink_path)?;
             Ok(())

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -144,7 +144,8 @@ pub fn select_binary_version(
         use std::os::windows::fs::symlink_file;
         let copy_binary = |_| {
             eprint!("WARNING: Unable to create symlink, copying binary instead. See https://github.com/superblk/terve#how-it-works{}", utils::NEWLINE);
-            copy(&opt_file_path, &symlink_path)
+            copy(&opt_file_path, &symlink_path)?;
+            Ok(())
         };
         symlink_file(&opt_file_path, &symlink_path).or_else(copy_binary)?;
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,7 +1,7 @@
 use std::{
     error::Error,
     fmt::Display,
-    fs::{create_dir_all, read_dir, read_link, remove_file},
+    fs::{create_dir_all, hard_link, read_dir, remove_file},
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -121,35 +121,19 @@ pub fn select_binary_version(
     version: String,
     dot_dir: DotDir,
 ) -> Result<String, Box<dyn Error>> {
-    let symlink_path = dot_dir.bin.join(&binary);
     let opt_file_path = dot_dir.opt.join(&binary).join(&version);
-    if !Path::new(&opt_file_path).exists() {
+    if !opt_file_path.exists() {
         return Err(format!(
             "{0} version {1} is not installed. Run 'terve install {0} {1}'",
             binary, version
         )
         .into());
     }
-    if read_link(&symlink_path).is_ok() {
-        remove_file(&symlink_path)?;
+    let hard_link_path = dot_dir.bin.join(&binary);
+    if hard_link_path.exists() {
+        remove_file(&hard_link_path)?;
     }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::symlink;
-        symlink(&opt_file_path, &symlink_path)?;
-    }
-    #[cfg(windows)]
-    {
-        use std::fs::copy;
-        use std::io;
-        use std::os::windows::fs::symlink_file;
-        let copy_binary = |_| -> io::Result<()> {
-            eprint!("WARNING: Unable to create symlink, copying binary instead. See https://github.com/superblk/terve#how-it-works{}", utils::NEWLINE);
-            copy(&opt_file_path, &symlink_path)?;
-            Ok(())
-        };
-        symlink_file(&opt_file_path, &symlink_path).or_else(copy_binary)?;
-    }
+    hard_link(&opt_file_path, &hard_link_path)?;
     Ok(format!("Selected {} {}", binary, version))
 }
 
@@ -158,15 +142,9 @@ pub fn remove_binary_version(
     version: String,
     dot_dir: DotDir,
 ) -> Result<String, Box<dyn Error>> {
-    let symlink_path = dot_dir.bin.join(&binary);
     let opt_file_path = dot_dir.opt.join(&binary).join(&version);
-    if Path::new(&opt_file_path).exists() {
+    if opt_file_path.exists() {
         remove_file(&opt_file_path)?;
-        let symlink_is_broken =
-            read_link(&symlink_path).is_ok() && !Path::new(&symlink_path).exists();
-        if symlink_is_broken {
-            remove_file(&symlink_path)?;
-        }
     }
     Ok(format!("Removed {} {}", binary, version))
 }


### PR DESCRIPTION
Symlink support on Windows 10 requires Developer mode or admin permissions, so refactor to use hard links instead